### PR TITLE
Add support for windows

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,8 +6,61 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build-wheels:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.10']
+    
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel pybind11 numpy
+    
+    - name: Build wheel
+      run: python setup.py bdist_wheel
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
+        path: dist/*.whl
 
+  build-sdist:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools pybind11
+    
+    - name: Build source distribution
+      run: python setup.py sdist
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
+  deploy:
+    needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
 
     environment:
@@ -17,17 +70,12 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
+    - name: Download all artifacts
+      uses: actions/download-artifact@v3
       with:
-        python-version: '3.10'
-    # prepare distributions in dist/
-    - name: Install dependencies and Build
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools pybind11
-        python setup.py sdist
+        path: dist/
+        merge-multiple: true
+    
     # publish by trusted publishers (need to first setup in pypi.org projects-manage-publishing!)
     # ref: https://github.com/marketplace/actions/pypi-publish
     - name: Publish package distributions to PyPI

--- a/include/meshiki/elements.h
+++ b/include/meshiki/elements.h
@@ -8,6 +8,8 @@
 
 using namespace std;
 
+#define M_PI 3.14159265358979323846f
+
 // forward declarations
 struct Facet;
 struct HalfEdge;

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
 import os
+import platform
 from setuptools import setup, find_packages
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
 _src_path = os.path.dirname(os.path.abspath(__file__))
+
+# Windows-specific compiler flags
+extra_compile_args = ["-std=c++17", "-O3"]
+
+if platform.system() == "Windows":
+    extra_compile_args = ["/std:c++17", "/O2"]
 
 setup(
     name="meshiki",
@@ -20,9 +27,9 @@ setup(
     ext_modules=[
         Pybind11Extension(
             name="_meshiki",
-            sources=["src/bindings.cpp"], # just cpp files
+            sources=["src/bindings.cpp"],  # just cpp files
             include_dirs=[os.path.join(_src_path, "include")],
-            extra_compile_args=["-std=c++17", "-O3"],
+            extra_compile_args=extra_compile_args,
         ),
     ],
     cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
When compiling meshiki on windows, it says `M_PI` is NOT defined 

I have added a simple macro define to solve this problem, and update `setup.py` and github workflow to support installation on windows.